### PR TITLE
Fix writing of buffered data, ensure chunks fit within 64kb SCTP packets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ after_failure:
 
 notifications:
   email:
-  - damon.oehlman@nicta.com.au
+  - nathan.oehlman@data61.csiro.au

--- a/index.js
+++ b/index.js
@@ -221,6 +221,10 @@ prot._dcsend = function(chunk, encoding, callback) {
     this.channel.send(chunk);
   }
   catch (e) {
+    // handle closed streams where we didn't get the memo
+    if (e.name == 'NetworkError') {
+      return this._handleClose();
+    }
     return callback(e);
   }
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var toBuffer = require('typedarray-to-buffer');
 var util = require('util');
 var closingStates = ['closing', 'closed'];
 var ENDOFSTREAM = '::endofstream';
+var MAX_CHUNK_SIZE = 1024 * 64;
 
 /**
   # rtc-dcstream
@@ -96,8 +97,14 @@ var prot = RTCChannelStream.prototype;
 prot._checkClear = function() {
   if (this.channel.bufferedAmount === 0) {
     clearInterval(this._clearTimer);
+    this._clearTimer = undefined;
     this._handleOpen();
   }
+};
+
+prot._ensureClearCheck = function() {
+  if (this._clearTimer) return;
+  this._clearTimer = setInterval(this._checkClear.bind(this), 100);
 };
 
 prot._debindChannel = function() {
@@ -152,19 +159,46 @@ prot._write = function(chunk, encoding, callback) {
     return false;
   }
 
-  // if we are connecting, then wait
-  if (this._wq.length || this.channel.readyState === 'connecting') {
-    return this._wq.push([ chunk, encoding, callback ]);
+  // process in chunks of an appropriate size for the data channel
+  var length = chunk.length || chunk.byteLength || chunk.size;
+  var numChunks = Math.ceil(length / MAX_CHUNK_SIZE);
+  var _returned = false;
+  debug('_write ' + length + ' in ' + numChunks + ' chunks');
+
+  function progressiveCallback(e) {
+    if (_returned || !e) return;
+    // Capture errors for writes that are split into multiple chunks and
+    // return to the root callback
+    _returned = true;
+    return callback(e);
   }
 
-  // if the channel is buffering, let's give it a rest
-  if (this.channel.bufferedAmount > 0) {
-    debug('data channel buffering ' + this.channel.bufferedAmount + ', backing off');
-    this._clearTimer = setInterval(this._checkClear.bind(this), 100);
-    return this._wq.push([ chunk, encoding, callback ]);
-  }
+  var result;
+  // To prevent overwhelming the data channel with a large write
+  // we ensure that writes are only for chunks within the MAX_CHUNK_SIZE
+  // If not, we split it up further into smaller chunks
+  for (var i = 0; i < numChunks; i++) {
+    var offset = i * MAX_CHUNK_SIZE;
+    var until = offset + MAX_CHUNK_SIZE;
+    var currentChunk = (numChunks === 1 ? chunk : chunk.slice(offset, until));
+    var ccLength = currentChunk.length || currentChunk.byteLength || currentChunk.size;
 
-  return this._dcsend(chunk, encoding, callback);
+    // Only callback after the entire attempted chunk is written
+    var currentCallback = (i + 1 === numChunks) ? callback : progressiveCallback;
+    // if we are connecting, then wait
+    if (this._wq.length || this.channel.readyState === 'connecting') {
+      result = this._wq.push([ currentChunk, encoding, currentCallback ]);
+    }
+    // if the channel is buffering, let's give it a rest
+    else if (this.channel.bufferedAmount > 0) {
+      debug('data channel buffering ' + this.channel.bufferedAmount + ', backing off');
+      this._ensureClearCheck();
+      result = this._wq.push([ currentChunk, encoding, currentCallback ]);
+    } else {
+      result = this._dcsend(currentChunk, encoding, currentCallback);
+    }
+  }
+  return result;
 };
 
 /**
@@ -187,11 +221,6 @@ prot._dcsend = function(chunk, encoding, callback) {
     this.channel.send(chunk);
   }
   catch (e) {
-    // handle closed streams where we didn't get the memo
-    if (e.name == 'NetworkError') {
-      return this._handleClose();
-    }
-
     return callback(e);
   }
 
@@ -232,12 +261,20 @@ prot._handleOpen = function(evt) {
   var peer = this;
   var queue = this._wq;
 
-  function sendNext(args) {
+  function sendNext() {
+
+    // Check that we are ready to send, if not, restart the timer
+    if (peer.channel.readyState !== 'open' || peer.channel.bufferedAmount > 0) {
+      debug('Not yet ready to resume sending queued write, backing off');
+      return peer._ensureClearCheck();
+    }
+
+    var args = queue.shift();
     var callback;
 
     // if we have no args, then abort
     if (! args) {
-      return queue.length ? sendNext(queue.shift()) : null;
+      return queue.length ? sendNext() : null;
     }
 
     // save the callback
@@ -245,7 +282,9 @@ prot._handleOpen = function(evt) {
 
     // replace with a new callback
     args[2] = function() {
-      sendNext(queue.shift());
+
+      // Queue up the next clearing of the queue
+      setTimeout(sendNext, 0);
 
       // trigger the callback
       if (typeof callback == 'function') {
@@ -253,10 +292,10 @@ prot._handleOpen = function(evt) {
       }
     };
 
-    peer._write.apply(peer, args);
+    peer._dcsend.apply(peer, args);
   }
 
   // send the queued messages
   debug('channel open, sending queued ' + queue.length + ' messages');
-  sendNext(queue.shift());
+  sendNext();
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "stability": "unstable",
   "scripts": {
-    "test": "testling -x start-$BROWSER",
+    "test": "browserify test/all.js | broth start | tap-spec",
     "gendocs": "gendocs > README.md"
   },
   "repository": {
@@ -25,6 +25,8 @@
   },
   "homepage": "https://github.com/rtc-io/rtc-dcstream",
   "devDependencies": {
+    "broth": "^2.0.0",
+    "browserify": "^9.0.3",
     "crel": "^2.1.6",
     "dropkick": "~0.1",
     "filestream": "^3.0.2",
@@ -35,10 +37,10 @@
     "scuttlebutt": "^5",
     "stream-spec": "~0.3",
     "stream-tester": "0.0.5",
+    "tap-spec": "^3.0.0",
     "tape": "^3.0.3",
-    "testling": "^1.7.1",
     "through": "^2",
-    "travis-multirunner": "^2.0.9"
+    "travis-multirunner": "^3.0.0"
   },
   "dependencies": {
     "cog": "^1.0.0",


### PR DESCRIPTION
This does a number of things:

- In the event that `_write` is called with a chunk that exceeds 64kb in size, that chunk is further broken down into smaller chunks that do fit within that size. This prevents failures on the data channel due to attempting to write more data to the data channel than it could handle in a single chunk (https://bugs.chromium.org/p/webrtc/issues/detail?id=2270). 

- Fixes the resuming of sending buffered data once the channel has recovered, in particular, the situation where there was more than 1 queued chunk. Due to the checking for the existence of queued chunks in `_write`, this meant that buffered writes were never processed, but just left waiting. Buffered writes will now write, and will also correctly respond to changes in the channel conditions (readyState or bufferedAmount)