### PR TITLE
Buffered data error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "stream"
   ],
   "author": "Damon Oehlman <damon.oehlman@nicta.com.au>",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/rtc-io/rtc-dcstream/issues"
   },


### PR DESCRIPTION
This patch addresses two issues:

1. If the underlying data channel has closed while data exists inside of the dcstream `_wq` write queue, it will no longer keep cycling through the `_ensureCheckClear` -> `_checkClear` -> `_handleOpen` cycle.

2. Attempts to identify when the underlying data channel (Chrome only) enters a stuck state - where the channel is for all intents and purposes open, but it refuses to send the contents of the underlying data channel buffer. This stuck state is particularly annoying as:
a) it hasn't yet been possible to determine the cause of the data channel getting stuck (all messages are getting handled successfully on the receiving peer, but once the writing peer gets stuff, no more messages are received on the receiving peer)
b) no errors are thrown on either the writing/reading peers.
c) it is not possible to close the data channel, as upon closing the channel, the channel enters the `closing` state, where it attempts to flush the data in it's buffer. Which... it can't do.

At any rate, when this situation is encountered, an error is thrown which will allow for remedial action to be taken (ie. restarting the peer connection)