### PR TITLE
Improve handling of stuck buffer failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - xvfb
 language: node_js
 node_js:
-- 6
+- 0.10
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
+services:
+  - xvfb
 language: node_js
 node_js:
-- 0.10
+- 6
 
 env:
   matrix:
@@ -21,12 +23,10 @@ matrix:
 
 before_script:
   - ./node_modules/travis-multirunner/setup.sh
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 after_failure:
   - for file in *.log; do echo $file; echo "======================"; cat $file; done || true
 
 notifications:
   email:
-  - nathan.oehlman@data61.csiro.au
+  - nathan+rtcio@coviu.com

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "tap-spec": "^3.0.0",
     "tape": "^3.0.3",
     "through": "^2",
-    "travis-multirunner": "^3.0.0"
+    "travis-multirunner": "^4.3.1",
   },
   "dependencies": {
     "cog": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "tap-spec": "^3.0.0",
     "tape": "^3.0.3",
     "through": "^2",
-    "travis-multirunner": "^4.3.1",
+    "travis-multirunner": "^4.3.1"
   },
   "dependencies": {
     "cog": "^1.0.0",


### PR DESCRIPTION
This PR attempts to do two things:

1) In the event of the buffer write timeout triggering, it does an additional check to see if the datachannel buffer is now empty

2) If the error still has to be thrown, it will report some additional data about the state of the data channel in the error message